### PR TITLE
Gallery Page OverHaul

### DIFF
--- a/RadPeople/src/components/GalleryOverlay.tsx
+++ b/RadPeople/src/components/GalleryOverlay.tsx
@@ -1,28 +1,37 @@
 import React from 'react';
-import { FiX } from 'react-icons/fi';
 import { GalleryItem } from '../models/Gallery.model';
 import {
   OverlayContainer,
   ImageGrid,
   ImageWrapper,
   Image,
-  CloseButton
+  CloseButton,
+  OverlayControlBar,
+  ImageCounter
 } from '../styles/GalleryOverlayStyles';
+import { ControlsGroup } from '../styles/GalleryStyles';
 
 interface GalleryOverlayProps {
   isOpen: boolean;
   images: GalleryItem[];
   onClose: () => void;
   onImageClick: (index: number) => void;
+  currentIndex?: number; // Add this prop
 }
 
-const GalleryOverlay: React.FC<GalleryOverlayProps> = ({ isOpen, images, onClose, onImageClick }) => {
+const GalleryOverlay: React.FC<GalleryOverlayProps> = ({ 
+  isOpen, 
+  images, 
+  onClose, 
+  onImageClick,
+  currentIndex = 0 // Default to 0 if not provided
+}) => {
   return (
     <OverlayContainer
       isOpen={isOpen}
       initial={{ opacity: 0 }}
       animate={isOpen ? { opacity: 1 } : { opacity: 0 }}
-      transition={{ duration: 0.15, ease: "easeInOut" }}  // Increased from 0.13 to 0.3
+      transition={{ duration: 0.15, ease: "easeInOut" }}
       onClick={(e) => e.stopPropagation()}
     >
       <ImageGrid>
@@ -30,7 +39,7 @@ const GalleryOverlay: React.FC<GalleryOverlayProps> = ({ isOpen, images, onClose
           <ImageWrapper 
             key={image.sys.id} 
             onClick={(e) => {
-              e.stopPropagation(); // Prevent event from bubbling up
+              e.stopPropagation();
               onImageClick(index);
             }}
           >
@@ -38,12 +47,25 @@ const GalleryOverlay: React.FC<GalleryOverlayProps> = ({ isOpen, images, onClose
           </ImageWrapper>
         ))}
       </ImageGrid>
-      <CloseButton onClick={(e) => {
-        e.stopPropagation();  // Prevent click from reaching gallery container
-        onClose();
-      }}>
-        <FiX />
-      </CloseButton>
+      
+      {/* Add the control bar */}
+      <OverlayControlBar>
+        <ControlsGroup>
+          <CloseButton onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}>
+            CLOSE
+          </CloseButton>
+        </ControlsGroup>
+        
+        {/* Right side with image counter */}
+        <ControlsGroup>
+          <ImageCounter>
+            {images.length} IMAGES
+          </ImageCounter>
+        </ControlsGroup>
+      </OverlayControlBar>
     </OverlayContainer>
   );
 };

--- a/RadPeople/src/components/NavBar.tsx
+++ b/RadPeople/src/components/NavBar.tsx
@@ -89,7 +89,7 @@ const NavBar: React.FC = memo(() => {
           </StyledNavLink>
         </NavLinks>
 
-        <CartLink to="/cart" as={Link}>cart</CartLink>
+        <CartLink to="/cart" as={Link}>CART</CartLink>
       </DesktopNav>
 
 

--- a/RadPeople/src/pages/Gallery.tsx
+++ b/RadPeople/src/pages/Gallery.tsx
@@ -1,11 +1,11 @@
-import { FiGrid } from 'react-icons/fi';
+import { FiArrowLeft, FiArrowRight, FiGrid } from 'react-icons/fi';
 import useIsMobile from '../hooks/useIsMobile';
 import PageWrapper from '../components/PageWrapper';
 import { AnimatePresence } from 'framer-motion';
 import GalleryOverlay from '../components/GalleryOverlay';
 import React, { useState, useEffect, useCallback } from 'react';
 import useGalleryNavigation from '../hooks/useGalleryNavigation';
-import { GalleryPageContainer, GalleryContainer, GalleryImage, ContactRectangle, OverlayButton } from '../styles/GalleryStyles';
+import { GalleryPageContainer, GalleryContainer, GalleryImage, ContactRectangle, OverlayButton, ControlBar, ControlsGroup, ControlBarButton, RightArrowButton, LeftArrowButton } from '../styles/GalleryStyles';
 import { useGallery } from '../contexts/GalleryContext';
 
 const Gallery: React.FC = () => {
@@ -77,6 +77,28 @@ const Gallery: React.FC = () => {
     }
   };
 
+  // Replace the handlePrevious function with this implementation
+  const handlePrevious = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Stop the event from reaching the container
+    console.log('Going to previous image, current index:', currentIndex);
+    
+    // Directly use setCurrentIndex with the same logic as goToPrevious
+    setCurrentIndex((prevIndex) => {
+      const newIndex = (prevIndex - 1 + images.length) % images.length;
+      console.log('Setting index to:', newIndex);
+      return newIndex;
+    });
+  };
+
+  // Create handler for next with direct index calculation
+  const handleNext = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // Calculate the new index directly based on the current index
+    const newIndex = (currentIndex + 1) % images.length;
+    console.log(`Next: ${currentIndex} → ${newIndex}`);
+    setCurrentIndex(newIndex); // Set directly to the calculated value
+  };
+
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
     // Ignore mouse moves when the overlay is open
     if (isOverlayOpen) return;
@@ -131,15 +153,34 @@ const Gallery: React.FC = () => {
           <p>contact@radpeople.us</p>
         </ContactRectangle>
 
-        <OverlayButton onClick={toggleOverlay}>
-          <FiGrid />
-        </OverlayButton>
-        
+        <ControlBar>
+          <ControlsGroup>
+            <ControlBarButton onClick={toggleOverlay}>
+              VIEW ALL
+            </ControlBarButton>
+          </ControlsGroup>
+          
+          {/* Right side controls with navigation arrows */}
+          <ControlsGroup>
+            {/* Image counter */}
+            <span>{currentIndex + 1} / {images.length}</span>
+            
+            {/* Navigation arrows */}
+            <LeftArrowButton onClick={handlePrevious} aria-label="Previous image">
+              <FiArrowLeft />
+            </LeftArrowButton>
+            <RightArrowButton onClick={handleNext} aria-label="Next image">
+              <FiArrowRight />
+            </RightArrowButton>
+          </ControlsGroup>
+        </ControlBar>
+      
         <GalleryOverlay
           isOpen={isOverlayOpen}
           images={images}
           onClose={toggleOverlay}
           onImageClick={handleOverlayImageClick}
+          currentIndex={currentIndex} // Pass the current index
         />
       </GalleryPageContainer>
     </PageWrapper>

--- a/RadPeople/src/styles/GalleryOverlayStyles.ts
+++ b/RadPeople/src/styles/GalleryOverlayStyles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { OverlayButton } from './GalleryStyles';
+import { ControlBar, OverlayButton } from './GalleryStyles';
 import { motion } from 'framer-motion';
 
 export const OverlayContainer = styled(motion.div)<{ isOpen: boolean }>`
@@ -11,20 +11,25 @@ export const OverlayContainer = styled(motion.div)<{ isOpen: boolean }>`
   background-color: white;
   z-index: 999;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   display: ${props => props.isOpen ? 'flex' : 'none'};
   border-top: 1px solid #000000;
+  flex-direction: column; // Keep this which is helping
 `;
 
 export const ImageGrid = styled.div`
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
-  padding: 25px; // Increased padding
-  gap: 20px; // Increased gap between images
-
+  padding: 25px;
+  padding-bottom: 250px; // Space for control bar on desktop
+  column-gap: 20px;
+  row-gap: 8px;
+  
   @media (max-width: 768px) {
     padding: 15px;
-    gap: 12px;
+    padding-bottom: 7vh; // Much larger padding to ensure no overlap
+    column-gap: 12px;
+    row-gap: 8px;
   }
 `;
 
@@ -32,11 +37,10 @@ export const ImageWrapper = styled.div`
   height: 140px;
   flex-grow: 0;
   flex-shrink: 0;
-  margin-bottom: 2px;
   cursor: pointer;
-
+  
   @media (max-width: 768px) {
-    height: 100px; // Decreased height for mobile devices
+    height: 100px;
   }
 `;
 
@@ -44,16 +48,53 @@ export const Image = styled.img`
   height: 100%;
   width: auto;
   object-fit: contain;
+  display: block; // Remove default inline spacing
+  margin: 0;
+  padding: 0;
+  line-height: 0;
 `;
 
-export const CloseButton = styled(OverlayButton)`
-  position: fixed;
-  bottom: 15px;
-  left: 15px;
-  z-index: 1001;
-  background-color: #0000FF;
-
+// Update the CloseButton styling
+export const CloseButton = styled.button`
+  background-color: transparent;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  padding: 5px;
+  margin: 0; // Remove any margin
+  color: black; // Explicitly set text color to black
+  font-size: 12px;
+  font-family: 'Sequel Sans Regular', sans-serif;
+  text-transform: uppercase;
+  
   svg {
-    stroke: white;
+    width: 24px; // Smaller icon size
+    height: 24px;
+    stroke: black;
+    stroke-width: 1.5; // Slightly thicker for visibility
+    fill: none;
   }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+// Add the OverlayControlBar component
+export const OverlayControlBar = styled(ControlBar)`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1002;
+`;
+
+// Add the ImageCounter component
+export const ImageCounter = styled.span`
+  font-family: 'Sequel Sans Regular', sans-serif;
+  font-size: 12px;
+  color: black;
+  margin-right: 15px;
 `;

--- a/RadPeople/src/styles/GalleryStyles.ts
+++ b/RadPeople/src/styles/GalleryStyles.ts
@@ -158,3 +158,63 @@ export const CloseButton = styled.button`
     outline: none;
   }
 `;
+
+
+// Add these new styled components
+export const ControlBar = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 4vh; // Match navbar height
+  background-color: white;
+  border-top: 1px solid #000000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 max(5px, calc((100vw - 100%) / 2)); // Match the FilterMenu padding style
+  z-index: 100;
+`;
+
+export const ControlBarButton = styled.button`
+  background-color: transparent;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  padding: 5px;
+  font-size: 12px;
+  color: black;
+  font-family: 'Sequel Sans Regular', sans-serif;
+  text-transform: uppercase;
+  
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const ControlsGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 15px;
+`;
+
+export const RightArrowButton = styled(ControlBarButton)`
+  margin-right: 15px; // Increased margin
+  
+  svg {
+    width: 18px; // Increase icon size
+    height: 18px;
+    stroke-width: 1.5; // Slightly thicker lines for better visibility
+  }
+`;
+
+// Also create a similar component for the left arrow for consistency
+export const LeftArrowButton = styled(ControlBarButton)`
+  svg {
+    width: 18px; // Increase icon size
+    height: 18px;
+    stroke-width: 1.5;
+  }
+`;

--- a/RadPeople/src/styles/NavBarStyles.ts
+++ b/RadPeople/src/styles/NavBarStyles.ts
@@ -100,7 +100,7 @@ export const CartLink = styled(RouterNavLink)`
   font-family: 'MotoyaExCedar', sans-serif;
   text-decoration: none;
   color: black;
-  font-size: 0.8rem; // Slightly reduced font size
+  font-size: 0.8rem;
   position: relative;
   transition: color 0.3s ease;
   


### PR DESCRIPTION
This includes a new Control bar at the bottom of the screen that replaces the previous view button. It also has a back and forth button, and the overlay to view all the images also incorporate this controlbar. It look just like the navbar, same styling and all. This makes the rest of the website consistent, and going away with the old buttons makes the site feel professional.